### PR TITLE
chore: Update license years

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 wk-j
+Copyright (c) 2018 - 2021 wk-j
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
License is not meant to be the first year only, but all the years when work was done. A range works well and is valid, instead of listing each.